### PR TITLE
Add option to ignore upcoming video premieres

### DIFF
--- a/include/Data.php
+++ b/include/Data.php
@@ -208,14 +208,18 @@ class Data
                 $video['duration'] = Convert::videoDuration($item->contentDetails->duration);
                 $video['tags'] = array();
                 $video['liveStream'] = false;
+                $video['premiere'] = false;
 
                 if ($item->snippet->liveBroadcastContent !== 'none') {
-                    $video['liveStream'] = true;
-                    $video['liveStreamStatus'] = $item->snippet->liveBroadcastContent;
-                    $video['liveStreamScheduled'] = 0;
-
                     if (isset($item->liveStreamingDetails->scheduledStartTime)) {
-                        $video['liveStreamScheduled'] = strtotime($item->liveStreamingDetails->scheduledStartTime);
+                        $video['scheduled'] = strtotime($item->liveStreamingDetails->scheduledStartTime);
+                    }
+
+                    if ($item->snippet->liveBroadcastContent === 'upcoming' && $video['duration'] !== 0) {
+                        $video['premiere'] = true;
+                    } else {
+                        $video['liveStream'] = true;
+                        $video['liveStreamStatus'] = $item->snippet->liveBroadcastContent;
                     }
                 }
 

--- a/include/Data.php
+++ b/include/Data.php
@@ -207,15 +207,17 @@ class Data
 
                 $video['duration'] = Convert::videoDuration($item->contentDetails->duration);
                 $video['tags'] = array();
-                $video['liveStream'] = false;
                 $video['premiere'] = false;
+                $video['liveStream'] = false;
 
                 if ($item->snippet->liveBroadcastContent !== 'none') {
+                    $video['scheduled'] = 0;
+
                     if (isset($item->liveStreamingDetails->scheduledStartTime)) {
                         $video['scheduled'] = strtotime($item->liveStreamingDetails->scheduledStartTime);
                     }
 
-                    if ($item->snippet->liveBroadcastContent === 'upcoming' && $video['duration'] !== 0) {
+                    if ($item->snippet->liveBroadcastContent === 'upcoming' && $video['duration'] !== '00:00') {
                         $video['premiere'] = true;
                     } else {
                         $video['liveStream'] = true;

--- a/include/FeedFormat/FeedFormat.php
+++ b/include/FeedFormat/FeedFormat.php
@@ -24,16 +24,20 @@ abstract class FeedFormat
     /** @var boolean $embedVideos Embed videos status */
     protected bool $embedVideos = false;
 
+    /** @var boolean $ignorePremieres Ignore upcoming video premieres */
+    protected bool $ignorePremieres = false;
+
     /**
      * @param array<string, mixed> $data Cache/fetch data
      * @param boolean $embedVideos Embed YouTube videos in feed
      * @param Config $config Config class instance
      */
-    public function __construct(array $data, bool $embedVideos, Config $config)
+    public function __construct(array $data, bool $embedVideos, bool $ignorePremieres, Config $config)
     {
         $this->config = $config;
         $this->data = $data;
         $this->embedVideos = $embedVideos;
+        $this->ignorePremieres = $ignorePremieres;
     }
 
     /**
@@ -157,6 +161,12 @@ HTML;
     {
         $emptyDuration = '00:00';
 
+        if ($video['premiere'] === true) {
+            $scheduled = $this->getFormattedScheduledDate($video['scheduled']);
+
+            return '[Premiere ' . $scheduled . '] ' . $video['title'] . ' (' . $video['duration'] . ')';
+        }
+
         if ($video['liveStream'] === true) {
             if ($video['liveStreamStatus'] === 'upcoming') {
                 $datetimeFormat = sprintf(
@@ -184,5 +194,20 @@ HTML;
         }
 
         return $video['title'] . ' (' . $video['duration'] . ')';
+    }
+
+    private function getFormattedScheduledDate(int $scheduled = 0): string
+    {
+        $datetimeFormat = sprintf(
+            '%s %s',
+            $this->config->getDateFormat(),
+            $this->config->getTimeFormat()
+        );
+
+        return Convert::unixTime(
+            $scheduled,
+            $datetimeFormat,
+            $this->config->getTimezone()
+        );
     }
 }

--- a/include/FeedFormat/FeedFormat.php
+++ b/include/FeedFormat/FeedFormat.php
@@ -196,6 +196,11 @@ HTML;
         return $video['title'] . ' (' . $video['duration'] . ')';
     }
 
+    /**
+     * Get formatted scheduled date string
+     * 
+     * @param int $scheduled Unix timestamp
+     */
     private function getFormattedScheduledDate(int $scheduled = 0): string
     {
         $datetimeFormat = sprintf(

--- a/include/FeedFormat/FeedFormat.php
+++ b/include/FeedFormat/FeedFormat.php
@@ -164,7 +164,7 @@ HTML;
         if ($video['premiere'] === true) {
             $scheduled = $this->getFormattedScheduledDate($video['scheduled']);
 
-            return '[Premiere ' . $scheduled . '] ' . $video['title'] . ' (' . $video['duration'] . ')';
+            return sprintf('[Premiere %s] %s (%s)', $scheduled, $video['title'], $video['duration']);
         }
 
         if ($video['liveStream'] === true) {
@@ -173,10 +173,10 @@ HTML;
 
                 // deprecated: used by v1.4.0 and before
                 if ($video['duration'] !== $emptyDuration) { // Has duration, is a video premiere
-                    return '[Premiere ' . $scheduled . '] ' . $video['title'] . ' (' . $video['duration'] . ')';
+                    return sprintf('[Premiere %s] %s (%s)', $scheduled, $video['title'], $video['duration']);
                 }
 
-                return '[Live Stream ' . $scheduled . '] ' . $video['title'];
+                return sprintf('[Live Stream %s] %s ', $scheduled, $video['title']);
             }
 
             if ($video['liveStreamStatus'] === 'live') {
@@ -184,7 +184,7 @@ HTML;
             }
         }
 
-        return $video['title'] . ' (' . $video['duration'] . ')';
+        return sprintf('%s (%s)', $video['title'], $video['duration']);
     }
 
     /**

--- a/include/FeedFormat/FeedFormat.php
+++ b/include/FeedFormat/FeedFormat.php
@@ -169,18 +169,9 @@ HTML;
 
         if ($video['liveStream'] === true) {
             if ($video['liveStreamStatus'] === 'upcoming') {
-                $datetimeFormat = sprintf(
-                    '%s %s',
-                    $this->config->getDateFormat(),
-                    $this->config->getTimeFormat()
-                );
+                $scheduled = $this->getFormattedScheduledDate($video['scheduled']);
 
-                $scheduled = Convert::unixTime(
-                    $video['liveStreamScheduled'],
-                    $datetimeFormat,
-                    $this->config->getTimezone()
-                );
-
+                // deprecated: used by v1.4.0 and before
                 if ($video['duration'] !== $emptyDuration) { // Has duration, is a video premiere
                     return '[Premiere ' . $scheduled . '] ' . $video['title'] . ' (' . $video['duration'] . ')';
                 }
@@ -198,7 +189,7 @@ HTML;
 
     /**
      * Get formatted scheduled date string
-     * 
+     *
      * @param int $scheduled Unix timestamp
      */
     private function getFormattedScheduledDate(int $scheduled = 0): string

--- a/include/FeedFormat/HtmlFormat.php
+++ b/include/FeedFormat/HtmlFormat.php
@@ -60,6 +60,10 @@ class HtmlFormat extends FeedFormat
         $items = '';
 
         foreach ($this->data['videos'] as $video) {
+            if ($video['premiere'] === true && $this->ignorePremieres === true) {
+                continue;
+            }
+
             $itemTitle = htmlEntities($this->buildTitle($video), ENT_QUOTES);
             $itemUrl = $video['url'];
             $itemCategories = $this->buildCategories($video['tags']);

--- a/include/FeedFormat/JsonFormat.php
+++ b/include/FeedFormat/JsonFormat.php
@@ -58,6 +58,10 @@ class JsonFormat extends FeedFormat
     {
         $items = array();
         foreach ($this->data['videos'] as $video) {
+            if ($video['premiere'] === true && $this->ignorePremieres === true) {
+                continue;
+            }
+
             $item = array();
             $item['id'] = $video['url'];
             $item['url'] = $video['url'];

--- a/include/FeedFormat/RssFormat.php
+++ b/include/FeedFormat/RssFormat.php
@@ -57,6 +57,10 @@ class RssFormat extends FeedFormat
         $items = '';
 
         foreach ($this->data['videos'] as $video) {
+            if ($video['premiere'] === true && $this->ignorePremieres === true) {
+                continue;
+            }
+
             $itemTitle = $this->xmlEncode(
                 $this->buildTitle($video)
             );

--- a/include/Helper/Url.php
+++ b/include/Helper/Url.php
@@ -30,14 +30,25 @@ class Url
      * @param string $id Feed id
      * @param string $format Feed format
      * @param boolean $embed Embed video status
+     * @param boolean $ignorePremieres Ignore premieres status
      * @return string
      */
-    public static function getFeed(string $selfUrl, string $type, string $id, string $format, bool $embed = false)
-    {
+    public static function getFeed(
+        string $selfUrl,
+        string $type,
+        string $id,
+        string $format,
+        bool $embed = false,
+        bool $ignorePremieres = false
+    ) {
         $url = $selfUrl . 'feed.php?' . $type . '_id=' . $id . '&format=' . $format;
 
         if ($embed === true) {
             $url .= '&embed_videos=true';
+        }
+
+        if ($ignorePremieres === true) {
+            $url .= '&ignore_premieres=true';
         }
 
         return $url;

--- a/include/Page/Feed.php
+++ b/include/Page/Feed.php
@@ -33,6 +33,9 @@ class Feed
     /** @var boolean $embedVideos Embed videos status */
     private bool $embedVideos = false;
 
+    /** @var boolean $ignorePremieres Ignore upcoming video premieres */
+    private bool $ignorePremieres = false;
+
     /**
      * @param array<string, mixed> $inputs Inputs parameters from `$_GET`
      * @param Config $config Config class instance
@@ -106,6 +109,7 @@ class Feed
         $format = new $formatClass(
             $this->getFeedData(),
             $this->getEmbedStatus(),
+            $this->ignorePremieres,
             $this->config
         );
 
@@ -160,6 +164,10 @@ class Feed
 
         if (isset($inputs['embed_videos'])) {
             $this->embedVideos = filter_var($inputs['embed_videos'], FILTER_VALIDATE_BOOLEAN);
+        }
+
+        if (isset($inputs['ignore_premieres'])) {
+            $this->ignorePremieres = filter_var($inputs['ignore_premieres'], FILTER_VALIDATE_BOOLEAN);
         }
 
         if (empty($this->feedId) === true) {

--- a/include/Page/Index.php
+++ b/include/Page/Index.php
@@ -25,6 +25,9 @@ class Index
     /** @var boolean $embedVideos Embed videos status */
     private bool $embedVideos = false;
 
+    /** @var boolean $ignorePremieres Ignore upcoming video premieres */
+    private bool $ignorePremieres = false;
+
     /** @var string $feedId YouTube channel or playlist ID */
     private string $feedId = '';
 
@@ -85,7 +88,8 @@ class Index
                 $this->feedType,
                 $this->feedId,
                 $this->feedFormat,
-                $this->embedVideos
+                $this->embedVideos,
+                $this->ignorePremieres
             );
 
             $link = sprintf('Feed URL: <a href="%s">%s</a>', $url, $url);
@@ -154,6 +158,10 @@ class Index
 
         if (isset($inputs['embed_videos'])) {
             $this->embedVideos = true;
+        }
+
+        if (isset($inputs['ignore_premieres'])) {
+            $this->ignorePremieres = filter_var($inputs['ignore_premieres'], FILTER_VALIDATE_BOOLEAN);
         }
     }
 

--- a/include/templates/index-page.html
+++ b/include/templates/index-page.html
@@ -33,7 +33,7 @@
 							<div class="input">
 								<label for="ignore_premieres_channel" class="checkbox-text">Ignore premieres:</label>
 								<input id="ignore_premieres_channel" class="checkbox" type="checkbox" name="ignore_premieres" value="yes">
-								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. Videos will be shown once they are available to watch.">[?]</span>
+								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. Videos will be shown when available to watch.">[?]</span>
 							</div>
 						</div>
 						<div class="form-option">
@@ -67,7 +67,7 @@
 							<div class="input">
 								<label for="ignore_premieres_playlist" class="checkbox-text">Ignore premieres:</label>
 								<input id="ignore_premieres_playlist" class="checkbox" type="checkbox" name="ignore_premieres" value="yes">
-								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. Videos will be shown once they are available to watch.">[?]</span>
+								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. Videos will be shown when available to watch.">[?]</span>
 							</div>
 						</div>
 						<div class="form-option">
@@ -101,7 +101,7 @@
 							<div class="input">
 								<label for="ignore_premieres_url" class="checkbox-text">Ignore premieres:</label>
 								<input id="ignore_premieres_url" class="checkbox" type="checkbox" name="ignore_premieres" value="yes">
-								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. Videos will be shown once they are available to watch.">[?]</span>
+								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. Videos will be shown when available to watch.">[?]</span>
 							</div>
 						</div>
 						<div class="form-option">

--- a/include/templates/index-page.html
+++ b/include/templates/index-page.html
@@ -30,6 +30,13 @@
 							</div>
 						</div>
 						<div class="form-option">
+							<div class="input">
+								<label for="ignore_premieres_channel" class="checkbox-text">Ignore premieres:</label>
+								<input id="ignore_premieres_channel" class="checkbox" type="checkbox" name="ignore_premieres" value="yes">
+								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. The videos will be shown once the premiere has started.">[?]</span>
+							</div>
+						</div>
+						<div class="form-option">
 							<label>Feed format: 
 								{selectHtml}
 							</label>
@@ -57,6 +64,13 @@
 							</div>
 						</div>
 						<div class="form-option">
+							<div class="input">
+								<label for="ignore_premieres_playlist" class="checkbox-text">Ignore premieres:</label>
+								<input id="ignore_premieres_playlist" class="checkbox" type="checkbox" name="ignore_premieres" value="yes">
+								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. The videos will be shown once the premiere has started.">[?]</span>
+							</div>
+						</div>
+						<div class="form-option">
 							<label>Feed format: 
 								{selectHtml}
 							</label>
@@ -81,6 +95,13 @@
 							<div class="input">
 								<label for="embed_videos_url" class="checkbox-text">Embed videos:</label>
 								<input id="embed_videos_url" class="checkbox" type="checkbox" name="embed_videos" value="yes">
+							</div>
+						</div>
+						<div class="form-option">
+							<div class="input">
+								<label for="ignore_premieres_url" class="checkbox-text">Ignore premieres:</label>
+								<input id="ignore_premieres_url" class="checkbox" type="checkbox" name="ignore_premieres" value="yes">
+								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. The videos will be shown once the premiere has started.">[?]</span>
 							</div>
 						</div>
 						<div class="form-option">

--- a/include/templates/index-page.html
+++ b/include/templates/index-page.html
@@ -33,7 +33,7 @@
 							<div class="input">
 								<label for="ignore_premieres_channel" class="checkbox-text">Ignore premieres:</label>
 								<input id="ignore_premieres_channel" class="checkbox" type="checkbox" name="ignore_premieres" value="yes">
-								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. The videos will be shown once the premiere has started.">[?]</span>
+								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. Videos will be shown once they are available to watch.">[?]</span>
 							</div>
 						</div>
 						<div class="form-option">
@@ -67,7 +67,7 @@
 							<div class="input">
 								<label for="ignore_premieres_playlist" class="checkbox-text">Ignore premieres:</label>
 								<input id="ignore_premieres_playlist" class="checkbox" type="checkbox" name="ignore_premieres" value="yes">
-								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. The videos will be shown once the premiere has started.">[?]</span>
+								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. Videos will be shown once they are available to watch.">[?]</span>
 							</div>
 						</div>
 						<div class="form-option">
@@ -101,7 +101,7 @@
 							<div class="input">
 								<label for="ignore_premieres_url" class="checkbox-text">Ignore premieres:</label>
 								<input id="ignore_premieres_url" class="checkbox" type="checkbox" name="ignore_premieres" value="yes">
-								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. The videos will be shown once the premiere has started.">[?]</span>
+								<span class="checkbox-note" title="Upcoming video premieres will not be show in the feed. Videos will be shown once they are available to watch.">[?]</span>
 							</div>
 						</div>
 						<div class="form-option">

--- a/static/style.css
+++ b/static/style.css
@@ -281,8 +281,14 @@ select {
 .checkbox-text {
     margin-top: 5px;
     margin-left: 5px;
-    width: 100px;
+    margin-right: 5px;
 }
+
+.checkbox-note {
+    margin-top: 5px;
+    margin-left: 5px;
+}
+
 
 .videoWrapper {
     position: relative;

--- a/tests/FeedFormat/JsonFormatTest.php
+++ b/tests/FeedFormat/JsonFormatTest.php
@@ -38,7 +38,7 @@ class JsonFormatTest extends TestCase
      */
     public function testBuild(): void
     {
-        $format = new JsonFormat($this->data, false, $this->config);
+        $format = new JsonFormat($this->data, false, false, $this->config);
         $format->build();
 
         $this->assertJsonStringEqualsJsonFile(
@@ -52,7 +52,7 @@ class JsonFormatTest extends TestCase
      */
     public function testGetContentType(): void
     {
-        $format = new JsonFormat($this->data, false, $this->config);
+        $format = new JsonFormat($this->data, false, false, $this->config);
         $format->build();
 
         $this->assertEquals('application/json', $format->getContentType());
@@ -63,7 +63,7 @@ class JsonFormatTest extends TestCase
      */
     public function testGetLastModified(): void
     {
-        $format = new JsonFormat($this->data, false, $this->config);
+        $format = new JsonFormat($this->data, false, false, $this->config);
         $format->build();
 
         $this->assertEquals('Wed, 18 Oct 2023 11:22:06 BST', $format->getLastModified());

--- a/tests/FeedFormat/RssFormatTest.php
+++ b/tests/FeedFormat/RssFormatTest.php
@@ -38,7 +38,7 @@ class RssFormatTest extends TestCase
      */
     public function testBuild(): void
     {
-        $format = new RssFormat($this->data, false, $this->config);
+        $format = new RssFormat($this->data, false, false, $this->config);
         $format->build();
 
         $expected = 'tests/files/FeedFormats/expected-rss-feed.xml';
@@ -53,7 +53,7 @@ class RssFormatTest extends TestCase
      */
     public function testGetContentType(): void
     {
-        $format = new RssFormat($this->data, false, $this->config);
+        $format = new RssFormat($this->data, false, false, $this->config);
         $format->build();
 
         $this->assertEquals('text/xml; charset=UTF-8', $format->getContentType());
@@ -64,7 +64,7 @@ class RssFormatTest extends TestCase
      */
     public function testGetLastModified(): void
     {
-        $format = new RssFormat($this->data, false, $this->config);
+        $format = new RssFormat($this->data, false, false, $this->config);
         $format->build();
 
         $this->assertEquals('Wed, 18 Oct 2023 11:22:06 BST', $format->getLastModified());

--- a/tests/Helper/UrlTest.php
+++ b/tests/Helper/UrlTest.php
@@ -25,7 +25,8 @@ class UrlTest extends TestCase
                 $item->type,
                 $item->id,
                 $item->format,
-                $item->embed
+                $item->embed,
+                $item->ignore_premieres
             ));
         }
     }

--- a/tests/files/channel-cache-data.json
+++ b/tests/files/channel-cache-data.json
@@ -32,6 +32,7 @@
                 "tomscott"
             ],
             "liveStream": false,
+            "premiere": false,
             "thumbnail": "https://i.ytimg.com/vi/CkZyZFa5qO0/maxresdefault.jpg",
             "fetched": 1697624526,
             "expires": 1697628126
@@ -49,6 +50,7 @@
                 "tomscott"
             ],
             "liveStream": false,
+            "premiere": false,
             "thumbnail": "https://i.ytimg.com/vi/ZgDBIzClmPg/maxresdefault.jpg",
             "fetched": 1697624526,
             "expires": 1697628126

--- a/tests/files/helper-url-samples.json
+++ b/tests/files/helper-url-samples.json
@@ -5,21 +5,24 @@
             "type": "channel",
             "id": "UC4QobU6STFB0P71PMvOGN5A",
             "format": "html",
-            "embed": false
+            "embed": false,
+            "ignore_premieres": false
         },
         {
-            "url": "https://example.com/feed.php?channel_id=UC4QobU6STFB0P71PMvOGN5A&format=rss&embed_videos=true",
+            "url": "https://example.com/feed.php?channel_id=UC4QobU6STFB0P71PMvOGN5A&format=rss&embed_videos=true&ignore_premieres=true",
             "type": "channel",
             "id": "UC4QobU6STFB0P71PMvOGN5A",
             "format": "rss",
-            "embed": true
+            "embed": true,
+            "ignore_premieres": true
         },
         {
-            "url": "https://example.com/feed.php?playlist_id=PLuhl9TnQPDCnWIhy_KSbtFwXVQnNvgfSh&format=json",
+            "url": "https://example.com/feed.php?playlist_id=PLuhl9TnQPDCnWIhy_KSbtFwXVQnNvgfSh&format=json&ignore_premieres=true",
             "type": "playlist",
             "id": "PLuhl9TnQPDCnWIhy_KSbtFwXVQnNvgfSh",
             "format": "json",
-            "embed": false
+            "embed": false,
+            "ignore_premieres": true
         }
     ],
     "thumbnails": [


### PR DESCRIPTION
Adds option to ignore upcoming video premieres when creating a feed.

![image](https://github.com/VerifiedJoseph/better-video-rss/assets/20118140/272bfd88-ef44-4688-9603-680ce81eea68)
