### PR TITLE
cache: Add format version number

### DIFF
--- a/include/Cache.php
+++ b/include/Cache.php
@@ -63,7 +63,7 @@ class Cache
      */
     public function save(array $data = []): void
     {
-        $data['version'] = $this->config->getVersion();
+        $data['version'] = $this->config->getCacheFormatVersion();
 
         if ($this->config->getCacheDisableStatus() === false) {
             File::write(

--- a/include/Cache.php
+++ b/include/Cache.php
@@ -95,13 +95,13 @@ class Cache
     }
 
     /**
-     * Check if better-video-rss version in cache matches current version. If not cache data array is emptied.
+     * Check if format version in cache matches current version. If not cache data array is emptied.
      */
     private function validateVersion(): void
     {
         if (array_key_exists('version', $this->data) === false) {
             $this->data = [];
-        } elseif ($this->data['version'] !== $this->config->getVersion()) {
+        } elseif ($this->data['version'] !== $this->config->getCacheFormatVersion()) {
             $this->data = [];
         }
     }

--- a/include/Config.php
+++ b/include/Config.php
@@ -222,11 +222,11 @@ class Config
 
     /**
      * Returns cache format version
-     * @return boolean
+     * @return int
      */
     public function getCacheFormatVersion(): int
     {
-        return (string) constant('CACHE_FORMAT_VERSION');
+        return (int) constant('CACHE_FORMAT_VERSION');
     }
 
     /**

--- a/include/Config.php
+++ b/include/Config.php
@@ -221,6 +221,15 @@ class Config
     }
 
     /**
+     * Returns cache format version status
+     * @return boolean
+     */
+    public function getCacheFormatVersion(): int
+    {
+        return (string) constant('CACHE_FORMAT_VERSION');
+    }
+
+    /**
      * Returns image proxy status
      * @return boolean
      */

--- a/include/Config.php
+++ b/include/Config.php
@@ -221,7 +221,7 @@ class Config
     }
 
     /**
-     * Returns cache format version status
+     * Returns cache format version
      * @return boolean
      */
     public function getCacheFormatVersion(): int

--- a/include/version.php
+++ b/include/version.php
@@ -8,3 +8,8 @@
  * @const VERSION BetterVideoRss version
  */
 define('VERSION', '1.5.3');
+
+/**
+ * @const CACHE_FORMAT_VERSION Cache format version number
+ */
+define('CACHE_FORMAT_VERSION', 1);

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -30,7 +30,7 @@ class CacheTest extends TestCase
         $config = self::createStub(Config::class);
         $config->method('getCacheDisableStatus')->willReturn(false);
         $config->method('getCacheDirPath')->willReturn(sys_get_temp_dir());
-        $config->method('getVersion')->willReturn('v0.0.0');
+        $config->method('getCacheFormatVersion')->willReturn(1);
         self::$config = $config;
     }
 
@@ -73,7 +73,7 @@ class CacheTest extends TestCase
         $config = self::createStub(Config::class);
         $config->method('getCacheDisableStatus')->willReturn(false);
         $config->method('getCacheDirPath')->willReturn(sys_get_temp_dir());
-        $config->method('getVersion')->willReturn('v1.0.0');
+        $config->method('getCacheFormatVersion')->willReturn(2);
 
         $cache = new Cache(self::$channelId, $config);
         $cache->load();

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -25,7 +25,7 @@ class DataTest extends TestCase
         $config = self::createStub(Config::class);
         $config->method('getCacheDisableStatus')->willReturn(false);
         $config->method('getCacheDirPath')->willReturn(sys_get_temp_dir());
-        $config->method('getVersion')->willReturn('v0.0.0');
+        $config->method('getCacheFormatVersion')->willReturn(1);
 
         return $config;
     }

--- a/tests/ProxyTest.php
+++ b/tests/ProxyTest.php
@@ -28,7 +28,7 @@ class ProxyTest extends TestCase
         $config->method('getDateFormat')->willReturn('F j, Y');
         $config->method('getTimeFormat')->willReturn('H:i');
         $config->method('getCacheDirPath')->willReturn(sys_get_temp_dir());
-        $config->method('getVersion')->willReturn('v0.0.0');
+        $config->method('getCacheFormatVersion')->willReturn(1);
         self::$config = $config;
     }
 

--- a/tests/files/channel-cache-data.json
+++ b/tests/files/channel-cache-data.json
@@ -121,5 +121,5 @@
         }
     ],
     "updated": 1697624526,
-    "version": "v0.0.0"
+    "version": 1
 }


### PR DESCRIPTION
Adds standalone version number for cache formats instead of using better-video-rss version number.