### PR TITLE
Enforce strict typing

### DIFF
--- a/cache-viewer.php
+++ b/cache-viewer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require 'vendor/autoload.php';
 
 use App\Config;

--- a/feed.php
+++ b/feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require 'vendor/autoload.php';
 
 use App\Config;

--- a/include/Api.php
+++ b/include/Api.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use App\Config;

--- a/include/Cache.php
+++ b/include/Cache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use App\Config;

--- a/include/Config.php
+++ b/include/Config.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use App\Config\Validate;

--- a/include/Config/Base.php
+++ b/include/Config/Base.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Config;
 
 abstract class Base

--- a/include/Config/Validate.php
+++ b/include/Config/Validate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Config;
 
 use App\Helper;

--- a/include/Data.php
+++ b/include/Data.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use App\Config;

--- a/include/Detect.php
+++ b/include/Detect.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 class Detect

--- a/include/Exception/ConfigException.php
+++ b/include/Exception/ConfigException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exception;
 
 use Throwable;

--- a/include/FeedFormat/FeedFormat.php
+++ b/include/FeedFormat/FeedFormat.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\FeedFormat;
 
 use App\Config;

--- a/include/FeedFormat/HtmlFormat.php
+++ b/include/FeedFormat/HtmlFormat.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\FeedFormat;
 
 use App\Template;

--- a/include/FeedFormat/JsonFormat.php
+++ b/include/FeedFormat/JsonFormat.php
@@ -9,6 +9,8 @@
  * https://json-feed-validator.herokuapp.com/validate
  */
 
+declare(strict_types=1);
+
 namespace App\FeedFormat;
 
 use App\Helper\Convert;

--- a/include/FeedFormat/RssFormat.php
+++ b/include/FeedFormat/RssFormat.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\FeedFormat;
 
 use App\Template;
 use App\Helper\Convert;
-use App\Helper\Url;
 
 class RssFormat extends FeedFormat
 {

--- a/include/Find.php
+++ b/include/Find.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use Exception;

--- a/include/Helper/Convert.php
+++ b/include/Helper/Convert.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Helper;
 
 use DateTime;

--- a/include/Helper/File.php
+++ b/include/Helper/File.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Helper;
 
 use Exception;

--- a/include/Helper/Format.php
+++ b/include/Helper/Format.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Helper;
 
 class Format

--- a/include/Helper/Json.php
+++ b/include/Helper/Json.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Helper;
 
 use stdClass;

--- a/include/Helper/Log.php
+++ b/include/Helper/Log.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Helper;
 
 class Log

--- a/include/Helper/Output.php
+++ b/include/Helper/Output.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Helper;
 
 use App\Helper\Log;

--- a/include/Helper/Url.php
+++ b/include/Helper/Url.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Helper;
 
 class Url

--- a/include/Helper/Validate.php
+++ b/include/Helper/Validate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Helper;
 
 use DateTimeZone;

--- a/include/Http/Request.php
+++ b/include/Http/Request.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http;
 
 use App\Http\Response;

--- a/include/Http/Response.php
+++ b/include/Http/Response.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http;
 
 class Response

--- a/include/Page/CacheViewer.php
+++ b/include/Page/CacheViewer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Page;
 
 use App\Config;

--- a/include/Page/Feed.php
+++ b/include/Page/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Page;
 
 use App\Config;

--- a/include/Page/Index.php
+++ b/include/Page/Index.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Page;
 
 use App\Config;

--- a/include/Template.php
+++ b/include/Template.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use App\Helper\File;

--- a/include/Version.php
+++ b/include/Version.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 class Version

--- a/index.php
+++ b/index.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require 'vendor/autoload.php';
 
 use App\Config;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,6 +6,10 @@
   <exclude-pattern>./coverage-reports</exclude-pattern>
 
   <rule ref="PSR12"/>
+  <rule ref="Generic.PHP.RequireStrictTypes">
+    <exclude-pattern>./config.php</exclude-pattern>
+    <exclude-pattern>./config.example.php</exclude-pattern>
+  </rule>
   <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
     <exclude-pattern>./tests/*</exclude-pattern>
   </rule>

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase as TestCase;
 use App\Config;
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/tests/Config/BaseTest.php
+++ b/tests/Config/BaseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Config;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Config/ValidateTest.php
+++ b/tests/Config/ValidateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Config;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Attributes\Depends;

--- a/tests/DetectTest.php
+++ b/tests/DetectTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use App\Detect;

--- a/tests/Exception/ConfigExceptionTest.php
+++ b/tests/Exception/ConfigExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use App\Exception\ConfigException;

--- a/tests/FeedFormat/HtmlFormatTest.php
+++ b/tests/FeedFormat/HtmlFormatTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use App\Config;

--- a/tests/FeedFormat/JsonFormatTest.php
+++ b/tests/FeedFormat/JsonFormatTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use App\Config;

--- a/tests/FeedFormat/RssFormatTest.php
+++ b/tests/FeedFormat/RssFormatTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use App\Config;

--- a/tests/FindTest.php
+++ b/tests/FindTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;

--- a/tests/Helper/ConvertTest.php
+++ b/tests/Helper/ConvertTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use App\Helper\Convert;

--- a/tests/Helper/FileTest.php
+++ b/tests/Helper/FileTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/tests/Helper/FormatTest.php
+++ b/tests/Helper/FormatTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use App\Helper\Format;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Helper/JsonTest.php
+++ b/tests/Helper/JsonTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use App\Helper\Json;

--- a/tests/Helper/UrlTest.php
+++ b/tests/Helper/UrlTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use App\Helper\Url;

--- a/tests/Helper/ValidateTest.php
+++ b/tests/Helper/ValidateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use App\Helper\Validate;

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use App\Http\Response;

--- a/tests/Page/FeedTest.php
+++ b/tests/Page/FeedTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use App\Config;

--- a/tests/Page/IndexTest.php
+++ b/tests/Page/IndexTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use App\Version;


### PR DESCRIPTION
Enforces strict typing by adding `declare(strict_types=1);` to all php files excluding `config.php` and `config.example.php`.